### PR TITLE
Use "phpfmt/fmt" composer package for PHPStorm docs

### DIFF
--- a/PHPStorm.md
+++ b/PHPStorm.md
@@ -12,7 +12,7 @@ git clone https://github.com/phpfmt/php.tools.git
 * Composer
 
 ```
-php composer.phar global require dericofilho/fmt
+php composer.phar global require phpfmt/fmt
 ```
 
 2 - Add php.tools as an External tool in PhpStorm : Open Settings (or “Preferences” on OS X) > External Tools and setup a new tool :


### PR DESCRIPTION
In the PHPStorm setup directions, it suggests using the
`deicofilho/fmt` package. If you use that package, composer throws a
“Package dericofilho/fmt is abandoned, you should avoid using it. Use
phpfmt/fmt instead.” warning.