### PR TITLE
Fix --dry-run option to remove itself from $argv

### DIFF
--- a/src/cli-core.php
+++ b/src/cli-core.php
@@ -204,6 +204,7 @@ if (isset($opts['no-backup'])) {
 
 $dryRun = false;
 if (isset($opts['dry-run'])) {
+	$argv = extractFromArgv($argv, 'dry-run');
 	$dryRun = true;
 }
 


### PR DESCRIPTION
Sorry for the poor quality of the initial PR; it slipped me this was a necessity. It's a follow-up fix to 074152e61be59d7e2ddce04dd32f4c050c971dcb .

Without this fix, using args like `--no-backup --dry-run somedir/` will spit out:
```
Files not found:
         - /somedir/--dry-run
```