### PR TITLE
Code after return should be indented

### DIFF
--- a/src/tests/397-return-indent.in
+++ b/src/tests/397-return-indent.in
@@ -1,0 +1,6 @@
+<?php
+function foo() {
+	return
+		1 === 1 &&
+		2 === 2;
+}

--- a/src/tests/397-return-indent.out
+++ b/src/tests/397-return-indent.out
@@ -1,0 +1,6 @@
+<?php
+function foo() {
+	return
+		1 === 1 &&
+		2 === 2;
+}


### PR DESCRIPTION
Currently fails with:
```DIFF
--- /Users/myuser/src/php.tools/src/tests/397-return-indent.out	2015-10-26 15:45:43.000000000 +0100
+++ /Users/myuser/src/php.tools/src/tests/397-return-indent.out-got	2015-10-26 15:45:47.000000000 +0100
@@ -1,6 +1,6 @@
 <?php
 function foo() {
 	return
-		1 === 1 &&
-		2 === 2;
+	1 === 1 &&
+	2 === 2;
 }
```
I think the lines following `return` should be indented once ore. What do you think?

I don't plan to provide a PR for the actual formatting change as I'm not sure if you guys want this and I'm not familiar with the internal code that much.