### PR TITLE
Arrays starting on next line should be indented

### DIFF
--- a/src/tests/398-array-starts-next-line.in
+++ b/src/tests/398-array-starts-next-line.in
@@ -1,0 +1,12 @@
+<?php
+$data =
+[
+	'foo' => 'bar',
+];
+
+$data = [
+	'foo' =>
+	[
+		'bar' => 'baz',
+	],
+];

--- a/src/tests/398-array-starts-next-line.out
+++ b/src/tests/398-array-starts-next-line.out
@@ -1,0 +1,12 @@
+<?php
+$data =
+	[
+		'foo' => 'bar',
+	];
+
+$data = [
+	'foo' =>
+		[
+			'bar' => 'baz',
+		],
+];


### PR DESCRIPTION
Shouldn't the array on the next line be indented?
```DIFF
--- /Users/myuser/src/php.tools/src/tests/398-array-starts-next-line.out	2015-10-26 16:08:10.000000000 +0100
+++ /Users/myuser/src/php.tools/src/tests/398-array-starts-next-line.out-got	2015-10-26 16:11:32.000000000 +0100
@@ -1,12 +1,12 @@
 <?php
 $data =
 	[
-		'foo' => 'bar',
-	];
+	'foo' => 'bar',
+];

 $data = [
 	'foo' =>
-		[
-			'bar' => 'baz',
-		],
+	[
+		'bar' => 'baz',
+	],
 ];
```